### PR TITLE
MPD Curl 302 workaorund

### DIFF
--- a/plugins/music_service/pandora/UIConfig.json
+++ b/plugins/music_service/pandora/UIConfig.json
@@ -13,7 +13,8 @@
         "label": "TRANSLATE.CONFIGURATION.PANDORA_SAVE_LABEL",
         "data": [
           "email",
-          "password"
+          "password",
+          "useCurl302WorkAround"
         ]
       },
       "content": [
@@ -32,6 +33,14 @@
           "doc": "TRANSLATE.CONFIGURATION.PANDORA_PASSWORD_DOC",
           "label": "TRANSLATE.CONFIGURATION.PANDORA_PASSWORD_LABEL",
           "value": ""
+        },
+        {
+          "id": "useCurl302WorkAround",
+          "type": "boolean",
+          "element": "switch",
+          "doc": "TRANSLATE.CONFIGURATION.PANDORA_USE_CURL_302_WORKAROUND_DOC",
+          "label": "TRANSLATE.CONFIGURATION.PANDORA_USE_CURL_302_WORKAROUND",
+          "value": "false"
         }
       ]
     }

--- a/plugins/music_service/pandora/i18n/strings_en.json
+++ b/plugins/music_service/pandora/i18n/strings_en.json
@@ -6,6 +6,8 @@
         "PANDORA_EMAIL_DOC": "Enter your email address you registered with Pandora.",
         "PANDORA_EMAIL_LABEL": "Email Address",
         "PANDORA_PASSWORD_DOC": "Enter your Pandora account password.",
-        "PANDORA_PASSWORD_LABEL": "Password"
+        "PANDORA_PASSWORD_LABEL": "Password",
+        "PANDORA_USE_CURL_302_WORKAROUND_DOC":"Rewrite stream URLs to use Pandora server's IP address rather than host name",
+        "PANDORA_USE_CURL_302_WORKAROUND":"Use Mpd Curl 302 workaround"
     }
 }

--- a/plugins/music_service/pandora/package.json
+++ b/plugins/music_service/pandora/package.json
@@ -18,6 +18,7 @@
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.0",
 		"anesidora": "^1.2.1",
-		"nanotimer": "^0.3.15"
+		"nanotimer": "^0.3.15",
+		"dns-sync": "^0.1.3"
 	}
 }


### PR DESCRIPTION
Added feature that provides and workaround for the MPD CURL 302 error messages that periodically occur and prevent Pandora songs from playing. Experimental.